### PR TITLE
Remove Azure subscription dependency for Fabric API authentication

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,13 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install fabric-cicd azure-identity
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Deploy to Dev Workspace
         run: |
           python scripts/deploy-to-fabric.py \
@@ -38,4 +31,7 @@ jobs:
             --environment dev \
             --workspace_name "${{ vars.WORKSPACE_NAME_DEV }}"
         env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,13 +48,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install fabric-cicd azure-identity
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Deploy to Production Workspace
         run: |
           python scripts/deploy-to-fabric.py \
@@ -62,4 +55,7 @@ jobs:
             --environment production \
             --workspace_name "${{ vars.WORKSPACE_NAME_PROD }}"
         env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -38,13 +38,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install fabric-cicd azure-identity
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Deploy to Test Workspace
         run: |
           python scripts/deploy-to-fabric.py \
@@ -52,4 +45,7 @@ jobs:
             --environment test \
             --workspace_name "${{ vars.WORKSPACE_NAME_TEST }}"
         env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}

--- a/AzDo/Deploy-To-Fabric.yml
+++ b/AzDo/Deploy-To-Fabric.yml
@@ -21,7 +21,7 @@ stages:
           - task: AzureCLI@2
             displayName: "Deploy Fabric Workspace"
             inputs:
-              azureSubscription: "SPN00"
+              azureSubscription: "SPN00"  # Service Connection needs Entra ID auth only, no subscription permissions required
               scriptType: "ps"
               scriptLocation: "inlineScript"
               inlineScript: |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Fabric Blueprint/
 ### Azure Setup
 
 1. **Azure Service Principal** with permissions:
-   - Fabric Workspace Admin or Contributor
-   - Azure subscription access
+   - Microsoft Entra ID (Azure AD) authentication
+   - Fabric Workspace Admin or Contributor permissions
+   - **Note**: No Azure subscription access required
 
 2. **Microsoft Fabric Workspaces**:
    - `[D] Fabric Blueprint` - Development environment
@@ -42,7 +43,6 @@ Configure the following **GitHub Secrets** in your repository:
 - `AZURE_CLIENT_ID` - Service Principal Client ID
 - `AZURE_CLIENT_SECRET` - Service Principal Secret
 - `AZURE_TENANT_ID` - Azure AD Tenant ID
-- `AZURE_SUBSCRIPTION_ID` - Azure Subscription ID
 
 **To add secrets**: Go to repository Settings → Secrets and variables → Actions → New repository secret
 
@@ -146,7 +146,7 @@ graph LR
 
 For each environment (Dev/Test/Prod):
 
-1. **Authenticate** to Azure using Service Principal
+1. **Authenticate** to Microsoft Entra ID using Service Principal (ClientSecretCredential)
 2. **Transform IDs** based on `parameter.yml` configuration
 3. **Deploy items** using `fabric-cicd` library
 4. **Clean up orphans** - remove items not in repository
@@ -200,8 +200,9 @@ item-name.ItemType/
 ### Common Issues
 
 **Deployment fails with authentication error**
-- Verify GitHub secrets are correctly configured
-- Check Service Principal has Fabric workspace permissions
+- Verify GitHub secrets are correctly configured (CLIENT_ID, CLIENT_SECRET, TENANT_ID)
+- Check Service Principal has Fabric workspace permissions (Admin or Contributor)
+- Ensure Service Principal is registered in correct Azure AD tenant
 
 **ID transformation not working**
 - Ensure `parameter.yml` has correct Dev workspace IDs

--- a/scripts/deploy-to-fabric.py
+++ b/scripts/deploy-to-fabric.py
@@ -1,4 +1,4 @@
-c# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 """Deploy workspace to Fabric via GitHub Actions"""
@@ -7,7 +7,7 @@ import argparse
 import os
 import sys
 
-from azure.identity import AzureCliCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from fabric_cicd import FabricWorkspace, change_log_level, publish_all_items, unpublish_all_orphan_items
 
 # Parse arguments from GitHub Actions workflow
@@ -35,8 +35,22 @@ print(f"Environment: {environment}")
 print(f"Repository directory: {repository_directory}")
 
 try:
-    # Use Azure CLI credential to authenticate
-    token_credential = AzureCliCredential()
+    # Use ClientSecretCredential for GitHub Actions or DefaultAzureCredential for local development
+    # GitHub Actions will provide these environment variables
+    client_id = os.getenv("AZURE_CLIENT_ID")
+    tenant_id = os.getenv("AZURE_TENANT_ID")
+    client_secret = os.getenv("AZURE_CLIENT_SECRET")
+    
+    if client_id and tenant_id and client_secret:
+        print("Using ClientSecretCredential for authentication")
+        token_credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret
+        )
+    else:
+        print("Using DefaultAzureCredential for authentication (local development)")
+        token_credential = DefaultAzureCredential()
 
     # Initialize the FabricWorkspace object with the required parameters
     target_workspace = FabricWorkspace(


### PR DESCRIPTION
Fixes #7

## Overview

This PR removes the Azure subscription dependency from the CI/CD pipeline. Microsoft Fabric API operations only require Microsoft Entra ID authentication and workspace-level permissions - **no Azure subscription access is needed**.

## Problem Statement

The current workflows fail when the Service Principal doesn't have Azure subscription access, even though Fabric API calls don't require it. This creates unnecessary complexity and follows a less secure approach (too many permissions).

## Changes Made

### 🔧 GitHub Actions Workflows
- **Removed** `azure/login@v2` step from all workflows (deploy-dev, deploy-test, deploy-prod)
- **Removed** `subscription-id` parameter requirement
- **Added** environment variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`) passed to Python script

### 🐍 Python Deployment Script
- **Changed** from `AzureCliCredential` to `ClientSecretCredential` for CI/CD authentication
- **Added** fallback to `DefaultAzureCredential` for local development scenarios
- **Improved** authentication logging for better troubleshooting

### 📚 Documentation Updates

#### README.md
- Removed `AZURE_SUBSCRIPTION_ID` from prerequisites and GitHub secrets list
- Updated authentication section to clarify only Entra ID auth is needed
- Updated troubleshooting guide with correct authentication requirements

#### SETUP.md
- Updated prerequisites to clarify no subscription access required
- Modified Azure Portal instructions to remove subscription ID collection
- Updated Azure CLI commands to use `--skip-assignment` (no subscription role needed)
- Removed `AZURE_SUBSCRIPTION_ID` from GitHub secrets configuration table
- Enhanced troubleshooting with correct authentication guidance

#### AzDo/Deploy-To-Fabric.yml
- Added comment clarifying Service Connection needs only Entra ID auth

## Benefits

✅ **Works with Fabric-only Service Principals** - No subscription access needed  
✅ **Principle of Least Privilege** - SP only needs workspace permissions  
✅ **Simpler Setup** - One less secret to manage (`AZURE_SUBSCRIPTION_ID` removed)  
✅ **Aligns with Microsoft Fabric Auth Model** - Uses `https://api.fabric.microsoft.com` correctly  
✅ **Better Security** - Reduced permission surface area  

## Breaking Changes

⚠️ **AZURE_SUBSCRIPTION_ID is no longer required**

### Migration Steps:
1. Merge this PR
2. (Optional) Remove `AZURE_SUBSCRIPTION_ID` from GitHub repository secrets - it's no longer used
3. Keep existing secrets: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
4. Existing Service Principals will continue to work (even if they have subscription access)

## Testing Checklist

- [ ] Deploy to Dev workflow runs successfully
- [ ] Deploy to Test workflow runs successfully  
- [ ] Deploy to Production workflow runs successfully
- [ ] Authentication works with Fabric-only Service Principal
- [ ] Local development with DefaultAzureCredential still works

## References

- [Microsoft Fabric REST API Authentication](https://learn.microsoft.com/rest/api/fabric/articles/authentication)
- [Microsoft Fabric API Reference](https://learn.microsoft.com/rest/api/fabric/)
- [Azure Identity ClientSecretCredential](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential)

## Review Focus Areas

1. Verify all workflow files correctly pass environment variables
2. Confirm Python script authentication logic is sound
3. Check documentation is clear about authentication requirements
4. Ensure no other references to subscription ID remain