### PR TITLE
Fix: Add pyyaml dependency for parameter.yml validation

### DIFF
--- a/.github/workflows/fabric-deploy.yml
+++ b/.github/workflows/fabric-deploy.yml
@@ -92,6 +92,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
       - name: Validate JSON files
         run: |
           echo "Validating JSON files..."


### PR DESCRIPTION
## Description
Fixes the `ModuleNotFoundError: No module named 'yaml'` error in the static-analysis job when validating workspace parameter.yml files.

## Changes
- Added Python dependencies installation step to the `static-analysis` job
- Installs `pyyaml` package before running YAML validation
- Ensures the `yaml` module is available for the validation script

## Problem
The workflow was failing during parameter.yml validation because the `yaml` module wasn't available:
```
ModuleNotFoundError: No module named 'yaml'
ERROR: Invalid YAML in workspaces/Fabric Blueprint/parameter.yml
```

## Solution
Added a new step after "Set up Python" that installs pip and pyyaml:
```yaml
- name: Install Python dependencies
  run: |
    python -m pip install --upgrade pip
    pip install pyyaml
```

## Testing
- [x] Workflow syntax is valid
- [ ] Static analysis job runs successfully
- [ ] YAML validation completes without errors

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update