### PR TITLE
Add CopyJob workspace and lakehouse ID transformations for Fabric Bronze

### DIFF
--- a/workspaces/Fabric Bronze/parameter.yml
+++ b/workspaces/Fabric Bronze/parameter.yml
@@ -17,21 +17,16 @@ find_replace:
       is_regex: "true"
       item_type: "SemanticModel"
 
-# TODO: Add lakehouse and workspace ID transformations once you have your Dev workspace IDs
-# Example entries (uncomment and update with actual IDs):
-#     - find_value: "your-dev-lakehouse-bronze-id"
-#       replace_value:
-#         _ALL_: "$items.Lakehouse.lakehouse_bronze.id"
-#       item_type: "Notebook"
-#     - find_value: "your-dev-lakehouse-silver-id"
-#       replace_value:
-#         _ALL_: "$items.Lakehouse.lakehouse_silver.id"
-#       item_type: "Notebook"
-#     - find_value: "your-dev-lakehouse-gold-id"
-#       replace_value:
-#         _ALL_: "$items.Lakehouse.lakehouse_gold.id"
-#       item_type: "Notebook"
-#     - find_value: "your-dev-workspace-id"
-#       replace_value:
-#         _ALL_: "$workspace.id"
-#       item_type: "Notebook"
+    # Replace workspace ID placeholder in CopyJobs
+    - find_value: "00000000-0000-0000-0000-000000000000"
+      replace_value:
+          _ALL_: "$workspace.id"
+      item_type: "CopyJob"
+      description: "Replace placeholder workspace ID with actual workspace ID"
+      
+    # Replace bronze lakehouse ID in CopyJobs
+    - find_value: "b892bcb4-b1d3-a9e0-4a9e-fac33bb0b654"
+      replace_value:
+          _ALL_: "$items.Lakehouse.lakehouse_bronze.id"
+      item_type: "CopyJob"
+      description: "Replace bronze lakehouse artifact ID with actual lakehouse ID"


### PR DESCRIPTION
Closes #25

## Changes
This PR adds parameter transformation rules to fix CopyJob deployment failures in the `Fabric Bronze` workspace.

### Problem
CopyJob `cp_br_source` was failing to deploy with error: "An error occurred while processing the operation." The CopyJob definition contained hardcoded environment-specific IDs:
- Workspace ID: `00000000-0000-0000-0000-000000000000` (placeholder)
- Lakehouse artifact ID: `b892bcb4-b1d3-a9e0-4a9e-fac33bb0b654` (from original environment)

These IDs don't exist in target workspaces, causing deployment failures.

### Solution
Added two transformation rules to `workspaces/Fabric Bronze/parameter.yml`:
1. **Workspace ID transformation**: Replaces placeholder `00000000-0000-0000-0000-000000000000` with `$workspace.id`
2. **Lakehouse artifact ID transformation**: Replaces hardcoded `b892bcb4-b1d3-a9e0-4a9e-fac33bb0b654` with `$items.Lakehouse.lakehouse_bronze.id`

The `fabric-cicd` library resolves these dynamic tokens at deployment time to the actual IDs in the target environment.

## Testing
- [x] Parameter file syntax validated
- [ ] Need to verify CopyJob deploys successfully to Dev environment after merge

## Deployment Considerations
- This change only affects `Fabric Bronze` workspace
- No changes to `Fabric Blueprint` workspace
- CopyJob will now reference correct workspace and lakehouse IDs dynamically

## Files Changed
- `workspaces/Fabric Bronze/parameter.yml`