### PR TITLE
Fix composite action: Move checkout step to workflow jobs

### DIFF
--- a/.github/actions/deploy-workspace/action.yml
+++ b/.github/actions/deploy-workspace/action.yml
@@ -23,9 +23,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/fabric-deploy.yml
+++ b/.github/workflows/fabric-deploy.yml
@@ -172,6 +172,9 @@ jobs:
       name: dev
       url: https://app.fabric.microsoft.com
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Deploy using composite action
         uses: ./.github/actions/deploy-workspace
         with:
@@ -241,6 +244,9 @@ jobs:
       name: test
       url: https://app.fabric.microsoft.com
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Deploy using composite action
         uses: ./.github/actions/deploy-workspace
         with:
@@ -279,6 +285,9 @@ jobs:
       name: prod
       url: https://app.fabric.microsoft.com
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Deploy using composite action
         uses: ./.github/actions/deploy-workspace
         with:


### PR DESCRIPTION
Composite actions cannot checkout themselves - the repository must be checked out before the action can be accessed. Moved checkout step from composite action to each deployment job.

Fixes action.yml not found error in GitHub Actions workflow.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] New feature (Lakehouse, Notebook, Pipeline, etc.)
- [ ] Bug fix
- [ ] Configuration change
- [ ] Documentation update
- [ ] Performance improvement

## Changes Made
<!-- List the specific changes made in this PR -->
- 
- 
- 

## Fabric Items Modified
<!-- List the Fabric items that were added, modified, or removed -->
### Added
- 

### Modified
- 

### Removed
- 

## Testing
<!-- Describe how these changes were tested -->
- [ ] Tested in private development workspace
- [ ] Validated locally with static analysis
- [ ] Verified notebook execution
- [ ] Checked data pipeline functionality
- [ ] Reviewed semantic model connections

## Deployment Checklist
<!-- Ensure these are complete before merging -->
- [ ] All item names follow naming conventions (cp_, nb_, lakehouse_, etc.)
- [ ] No hardcoded IDs or environment-specific values
- [ ] parameter.yml updated if new IDs need transformation
- [ ] Documentation updated (if needed)
- [ ] Commit messages are clear and descriptive
- [ ] No sensitive information in commit history

## Post-Deployment Tasks
<!-- List any manual tasks required after deployment -->
- [ ] Verify deployment to Dev workspace
- [ ] Test functionality in Dev environment
- [ ] Update workspace shortcuts (if needed)
- [ ] Refresh semantic models (if applicable)

## Related Issues
<!-- Link to related GitHub issues -->
Closes #

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->
