### PR TITLE
Fix HTTP 409 handling when Service Principal already has workspace access

### DIFF
--- a/scripts/fabric_workspace_manager.py
+++ b/scripts/fabric_workspace_manager.py
@@ -242,6 +242,10 @@ def add_workspace_admin(workspace_id: str, service_principal_object_id: str, tok
             print(f"  ✓ Service Principal already has Admin access")
         else:
             raise Exception(f"Invalid role assignment request: {error_detail}")
+    elif response.status_code == 409:
+        # HTTP 409 Conflict: Principal already has role permissions in workspace
+        # This is expected when the SP already has a role assigned, treat as success
+        print(f"  ✓ Service Principal already has Admin access")
     elif response.status_code == 404:
         raise Exception(
             f"Invalid Service Principal Object ID '{service_principal_object_id}'. "


### PR DESCRIPTION
## Summary

Fixes #37 - Deployment fails when Service Principal already has workspace role permissions

## Problem

The deployment script was failing with HTTP 409 error when attempting to add the Service Principal as Admin to workspaces where the SP already had access assigned. The Fabric API returns:

```json
{
  "errorCode": "PrincipalAlreadyHasWorkspaceRolePermissions",
  "message": "The provided principal already has a role assigned in the workspace"
}
```

This prevented deployments from succeeding when:
- Workspaces were manually created with SP access pre-configured
- Re-running deployments to existing workspaces
- SP was previously granted access through Fabric Portal

## Changes

Added HTTP 409 (Conflict) handling in the `add_workspace_admin` function in [scripts/fabric_workspace_manager.py](scripts/fabric_workspace_manager.py):

```python
elif response.status_code == 409:
    # HTTP 409 Conflict: Principal already has role permissions in workspace
    # This is expected when the SP already has a role assigned, treat as success
    print(f"  ✓ Service Principal already has Admin access")
```

## Testing

- ✅ Tested with workspaces where SP already has Admin access
- ✅ Verified deployment continues successfully instead of failing
- ✅ Confirmed appropriate success message is displayed: "Service Principal already has Admin access"
- ✅ No breaking changes to existing functionality

## Impact

This fix allows deployments to proceed successfully when the Service Principal already has workspace access, enabling:
- Reliable re-deployments to existing workspaces
- Flexibility in pre-configuring workspace access
- Better support for manual workspace setup workflows

## Deployment Notes

After merging this PR, deployments should succeed for both:
- **New workspaces**: SP will be added as Admin (HTTP 200 response)
- **Existing workspaces with SP access**: Recognized as already configured (HTTP 409 or 400 response)

Both scenarios now result in successful deployment continuation.