### PR TITLE
Add Entra ID admin group support for workspace provisioning

### DIFF
--- a/.github/workflows/fabric-deploy.yml
+++ b/.github/workflows/fabric-deploy.yml
@@ -188,6 +188,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           FABRIC_CAPACITY_ID_DEV: ${{ secrets.FABRIC_CAPACITY_ID_DEV }}
           DEPLOYMENT_SP_OBJECT_ID: ${{ secrets.DEPLOYMENT_SP_OBJECT_ID }}
+          FABRIC_ADMIN_GROUP_ID: ${{ secrets.FABRIC_ADMIN_GROUP_ID }}
 
       - name: Deployment Summary
         if: always()
@@ -292,6 +293,7 @@ jobs:
           FABRIC_CAPACITY_ID_TEST: ${{ secrets.FABRIC_CAPACITY_ID_TEST }}
           FABRIC_CAPACITY_ID_PROD: ${{ secrets.FABRIC_CAPACITY_ID_PROD }}
           DEPLOYMENT_SP_OBJECT_ID: ${{ secrets.DEPLOYMENT_SP_OBJECT_ID }}
+          FABRIC_ADMIN_GROUP_ID: ${{ secrets.FABRIC_ADMIN_GROUP_ID }}
 
       - name: Deployment Summary
         if: always()
@@ -366,6 +368,7 @@ jobs:
           FABRIC_CAPACITY_ID_TEST: ${{ secrets.FABRIC_CAPACITY_ID_TEST }}
           FABRIC_CAPACITY_ID_PROD: ${{ secrets.FABRIC_CAPACITY_ID_PROD }}
           DEPLOYMENT_SP_OBJECT_ID: ${{ secrets.DEPLOYMENT_SP_OBJECT_ID }}
+          FABRIC_ADMIN_GROUP_ID: ${{ secrets.FABRIC_ADMIN_GROUP_ID }}
 
       - name: Deployment Summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -67,9 +67,25 @@ No GitHub variables needed - names are automatically generated from folder names
 ### GitHub Setup
 
 Configure the following **GitHub Secrets** in your repository:
+
+**Required Secrets:**
 - `AZURE_CLIENT_ID` - Service Principal Client ID
 - `AZURE_CLIENT_SECRET` - Service Principal Secret
 - `AZURE_TENANT_ID` - Azure AD Tenant ID
+
+**Optional Secrets (for workspace auto-creation and admin group):**
+- `FABRIC_CAPACITY_ID_DEV` - Dev capacity ID (enables auto-creation)
+- `FABRIC_CAPACITY_ID_TEST` - Test capacity ID (enables auto-creation)
+- `FABRIC_CAPACITY_ID_PROD` - Prod capacity ID (enables auto-creation)
+- `DEPLOYMENT_SP_OBJECT_ID` - Service Principal Object ID for workspace admin role
+- `FABRIC_ADMIN_GROUP_ID` - Entra ID group Object ID for centralized admin access (recommended)
+
+**About FABRIC_ADMIN_GROUP_ID:**
+- Assigns an Entra ID (Azure AD) security group as admin to all deployed workspaces
+- Enables centralized access management through Azure AD group membership
+- All group members automatically receive Admin permissions to workspaces
+- Must be stored as a GitHub Secret for security (never commit to repository)
+- Optional but recommended for team-based access management
 
 **To add secrets**: Go to repository Settings → Secrets and variables → Actions → New repository secret
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -181,6 +181,7 @@ If you completed Step 1b (Workspace Creator permission), the deployment pipeline
 | `FABRIC_CAPACITY_ID_TEST` | Test Fabric capacity GUID | Fabric Admin Portal → Capacity Settings → Test capacity |
 | `FABRIC_CAPACITY_ID_PROD` | Prod Fabric capacity GUID | Fabric Admin Portal → Capacity Settings → Prod capacity |
 | `DEPLOYMENT_SP_OBJECT_ID` | Service Principal Object ID (NOT Client ID) | Azure AD → Enterprise Applications → Your app → Object ID |
+| `FABRIC_ADMIN_GROUP_ID` | Entra ID (Azure AD) group for workspace admin access | Azure AD → Groups → Your admin group → Object ID |
 
 **⚠️ Important: Object ID vs Client ID**
 - `AZURE_CLIENT_ID` = Application (Client) ID from App Registration
@@ -192,6 +193,19 @@ If you completed Step 1b (Workspace Creator permission), the deployment pipeline
 2. Search for your application using the **Client ID** (Application ID)
 3. Click on the application
 4. Copy the **Object ID** field at the top
+
+**How to find Entra ID Group Object ID (for FABRIC_ADMIN_GROUP_ID):**
+1. Azure Portal → **Azure Active Directory** → **Groups**
+2. Search for your admin group
+3. Click on the group
+4. Copy the **Object ID** field
+
+**Note about FABRIC_ADMIN_GROUP_ID:**
+- This is **optional** but recommended for centralized access management
+- If configured, all members of this Entra ID group will automatically receive **Admin** permissions to all deployed workspaces
+- This allows you to manage workspace access through Azure AD group membership instead of individual user assignments
+- The group is assigned admin access when workspaces are created or updated via the deployment pipeline
+- **Security**: The group ID must be stored as a GitHub Secret, never commit it to the repository
 
 **Note**: If you don't configure the capacity secrets, you must manually create all workspaces before deployment.
 

--- a/scripts/deploy-to-fabric.py
+++ b/scripts/deploy-to-fabric.py
@@ -47,7 +47,8 @@ def deploy_workspace(
     environment: str,
     token_credential,
     capacity_id: str = None,
-    service_principal_object_id: str = None
+    service_principal_object_id: str = None,
+    entra_admin_group_id: str = None
 ) -> tuple[bool, str]:
     """Deploy a single workspace.
     
@@ -63,6 +64,8 @@ def deploy_workspace(
             role assignment when a new workspace is created. Required for auto-creation
             scenarios where the service principal should be granted access; optional if
             the workspace already exists and no new role assignment is needed.
+        entra_admin_group_id: Optional Azure AD Object ID of Entra ID group to grant
+            admin permissions. If provided, the group will be assigned as a workspace admin.
         
     Returns:
         Tuple of (success: bool, error_message: str). Error message is empty string if successful.
@@ -87,7 +90,8 @@ def deploy_workspace(
             workspace_name=workspace_name,
             capacity_id=capacity_id,
             service_principal_object_id=service_principal_object_id,
-            token_credential=token_credential
+            token_credential=token_credential,
+            entra_admin_group_id=entra_admin_group_id
         )
         print(f"→ Workspace ensured with ID: {workspace_id}")
         
@@ -179,6 +183,7 @@ def main():
             capacity_id = os.getenv("FABRIC_CAPACITY_ID_PROD")
         
         service_principal_object_id = os.getenv("DEPLOYMENT_SP_OBJECT_ID")
+        entra_admin_group_id = os.getenv("FABRIC_ADMIN_GROUP_ID")
         
         # Determine which workspaces to deploy
         if workspace_folders_arg:
@@ -210,7 +215,8 @@ def main():
                 environment=environment,
                 token_credential=token_credential,
                 capacity_id=capacity_id,
-                service_principal_object_id=service_principal_object_id
+                service_principal_object_id=service_principal_object_id,
+                entra_admin_group_id=entra_admin_group_id
             )
             
             if success:


### PR DESCRIPTION
Closes #43

## Summary
This PR implements support for assigning an Entra ID (Azure AD) security group as a workspace admin during workspace provisioning. This enables centralized access management through Azure AD group membership instead of individual user assignments.

## Changes Made

### 1. Workspace Manager (`fabric_workspace_manager.py`)
- ✅ Added `add_entra_id_group_admin()` function to support Entra ID group assignment
- ✅ Updated `ensure_workspace_exists()` to accept and use `entra_admin_group_id` parameter
- ✅ Implements Fabric REST API role assignment with principal type "Group"
- ✅ Gracefully handles cases where group is already assigned (409 conflict)

### 2. Deployment Script (`deploy-to-fabric.py`)
- ✅ Read `FABRIC_ADMIN_GROUP_ID` from environment variables
- ✅ Pass admin group ID to `ensure_workspace_exists()` for all workspace deployments
- ✅ Updated function signatures and docstrings

### 3. GitHub Actions Workflow (`.github/workflows/fabric-deploy.yml`)
- ✅ Added `FABRIC_ADMIN_GROUP_ID` secret to all deployment jobs (dev, test, prod)
- ✅ Secret is passed as environment variable to deployment script

### 4. Documentation
- ✅ Updated `SETUP.md` with instructions for finding Entra ID group Object ID
- ✅ Added security notes about storing group ID as GitHub Secret
- ✅ Updated `README.md` with new optional secret `FABRIC_ADMIN_GROUP_ID`
- ✅ Documented benefits of centralized access management

## Important Findings

### Capacity Admin Retrieval
❌ **NOT SUPPORTED**: The Fabric REST API does not provide endpoints to programmatically query capacity admins. After reviewing Microsoft Fabric API documentation, capacity admin configuration is managed at the Azure resource level and cannot be retrieved via the Fabric API.

### Entra ID Group Assignment
✅ **FULLY SUPPORTED**: Entra ID groups can be assigned as workspace admins using the Fabric workspace role assignment API with `"type": "Group"`. This provides a better solution for centralized access management.

## Configuration

### New GitHub Secret (Optional)
- **Name**: `FABRIC_ADMIN_GROUP_ID`
- **Value**: Azure AD Object ID of your admin security group
- **Where to find**: Azure Portal → Azure Active Directory → Groups → Your group → Object ID

### Benefits
- Centralized access management through Azure AD group membership
- All group members automatically receive Admin permissions to deployed workspaces
- No need to manage individual user permissions per workspace
- Follows security best practices (group ID stored as secret, not in code)

## Testing Checklist
- [x] Code follows project conventions (Python PEP 8, proper docstrings)
- [x] Function signatures updated with type hints
- [x] Error handling implemented for API failures
- [x] Documentation updated (SETUP.md, README.md)
- [x] GitHub workflow updated to pass new secret
- [x] Changes are backward compatible (admin group is optional)

## Acceptance Criteria from Issue #43
- [x] Investigate Fabric API capabilities for querying capacity admins → **NOT SUPPORTED**
- [x] ~~Implement capacity admin retrieval and assignment logic~~ → **SKIPPED** (API doesn't support it)
- [x] Add GitHub Secret configuration for `FABRIC_ADMIN_GROUP_ID`
- [x] Update GitHub Actions workflows to pass the admin group ID as an environment variable
- [x] Implement Entra ID group assignment during workspace provisioning using the secret value
- [x] Update documentation with new GitHub Secret configuration requirements
- [x] Update SETUP.md with instructions for setting the admin group secret
- [x] Security: Group ID stored as GitHub Secret (not in parameter.yml or committed files)

## Deployment Impact
- ✅ **Backward Compatible**: If `FABRIC_ADMIN_GROUP_ID` is not set, deployment continues without errors
- ✅ **No Breaking Changes**: Existing workspaces and deployments are not affected
- ✅ **Optional Feature**: Can be enabled by setting the GitHub Secret

## Security Notes
- Group ID must be stored as GitHub Secret (`FABRIC_ADMIN_GROUP_ID`)
- Never commit group IDs to repository or parameter.yml files
- Follows same security pattern as existing secrets (CLIENT_ID, CLIENT_SECRET, TENANT_ID)