### PR TITLE
Fix Service Principal workspace creation error message and documentation

### DIFF
--- a/scripts/fabric_workspace_manager.py
+++ b/scripts/fabric_workspace_manager.py
@@ -178,9 +178,12 @@ def create_workspace(workspace_name: str, capacity_id: str, token_credential: Un
         raise Exception(f"Invalid workspace creation request: {error_detail}")
     elif response.status_code == 403:
         raise Exception(
-            "Service Principal lacks 'Workspace Creator' permission. "
-            "Grant this permission in Fabric Admin Portal → Tenant Settings → Developer Settings → "
-            "Service Principals can create and edit Fabric workspaces."
+            "Service Principal lacks workspace creation permissions.\n\n"
+            "Possible causes:\n"
+            "1. Missing tenant setting: In Fabric Admin Portal → Tenant Settings → Developer Settings, "
+            "enable 'Service principals can create workspaces, connections, and deployment pipelines'\n"
+            "2. Missing capacity admin role: In Azure Portal → Fabric Capacity → Settings → Capacity administrators, "
+            "add the Service Principal (by Client ID or Enterprise Application Object ID)"
         )
     elif response.status_code == 404:
         raise Exception(f"Invalid capacity ID '{capacity_id}'. Verify FABRIC_CAPACITY_ID_* secret is correct.")
@@ -390,12 +393,18 @@ def ensure_workspace_exists(
         print(f"\n✗ ERROR: Failed to ensure workspace exists: {error_msg}\n")
         
         # Add troubleshooting hints
-        if "Workspace Creator" in error_msg:
+        if "workspace creation permissions" in error_msg:
             print("TROUBLESHOOTING:")
-            print("  1. Open Fabric Admin Portal (https://app.fabric.microsoft.com/admin-portal)")
-            print("  2. Navigate to: Tenant Settings → Developer Settings")
-            print("  3. Enable: 'Service Principals can create and edit Fabric workspaces'")
-            print("  4. Add your Service Principal to the allowed list")
+            print("  1. Fabric Tenant Setting:")
+            print("     - Open Fabric Admin Portal (https://app.fabric.microsoft.com/admin-portal)")
+            print("     - Navigate to: Tenant Settings → Developer Settings")
+            print("     - Enable: 'Service principals can create workspaces, connections, and deployment pipelines'")
+            print("     - Add your Service Principal to the allowed list")
+            print("  2. Capacity Administrator Assignment:")
+            print("     - Open Azure Portal → Your Fabric Capacity → Settings")
+            print("     - Under 'Capacity administrators', click Add")
+            print("     - Enter the Service Principal's Client ID (Application ID) or search by Enterprise Application name")
+            print("     - Note: This is NOT done through Access Control (IAM) - it's a dedicated 'Capacity administrators' setting")
             print()
         elif "capacity" in error_msg.lower():
             print("TROUBLESHOOTING:")


### PR DESCRIPTION
Closes #42

## Summary

This PR fixes the Service Principal workspace creation error message and documentation to provide complete troubleshooting information for 403 Forbidden errors during workspace auto-creation.

## Changes Made

### 1. Updated Error Message in `fabric_workspace_manager.py`
- **Changed**: Updated 403 error to mention **both** possible causes instead of only the tenant setting
- **Fixed**: Corrected outdated tenant setting name from "Service Principals can create and edit Fabric workspaces" to "Service principals can create workspaces, connections, and deployment pipelines"
- **Added**: Capacity administrator assignment as a required configuration

**New error message:**
```
Service Principal lacks workspace creation permissions.

Possible causes:
1. Missing tenant setting: In Fabric Admin Portal → Tenant Settings → Developer Settings, enable 'Service principals can create workspaces, connections, and deployment pipelines'
2. Missing capacity admin role: In Azure Portal → Fabric Capacity → Settings → Capacity administrators, add the Service Principal (by Client ID or Enterprise Application Object ID)
```

### 2. Enhanced Troubleshooting Hints
- Updated the troubleshooting section to include capacity administrator assignment steps
- Added clear distinction that capacity admin is NOT configured through IAM
- Provided step-by-step instructions for both configurations

### 3. Updated Documentation in `SETUP.md`
- Renamed "Step 1b" to "Configure Service Principal for Workspace Creation"
- Added comprehensive section explaining **TWO required configurations**:
  1. Fabric tenant setting
  2. Capacity administrator assignment
- Added critical warnings about both being required
- Provided detailed steps for configuring capacity admin in Azure Portal
- Clarified that IAM is NOT the correct place for this configuration

## Testing Considerations

This is a **documentation and error message update only** - no functional code changes:
- ✅ Error message now provides complete troubleshooting information
- ✅ Documentation matches current Fabric tenant setting name
- ✅ Users will now understand both configuration requirements

## Why This Matters

The previous error message was incomplete and could lead to:
- Wasted troubleshooting time when the actual issue was capacity admin assignment
- Confusion about outdated setting names
- Failed deployments even when tenant settings were correctly configured

This fix ensures users get complete information to resolve 403 workspace creation errors on first attempt.