### PR TITLE
Remove static-analysis job from deployment workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,6 @@
 ## Testing
 <!-- Describe how these changes were tested -->
 - [ ] Tested in private development workspace
-- [ ] Validated locally with static analysis
 - [ ] Verified notebook execution
 - [ ] Checked data pipeline functionality
 - [ ] Reviewed semantic model connections

--- a/.github/workflows/fabric-deploy.yml
+++ b/.github/workflows/fabric-deploy.yml
@@ -55,77 +55,6 @@ jobs:
           echo "workspaces=$all_workspaces" >> $GITHUB_OUTPUT
           echo "Workspaces to deploy: $all_workspaces"
 
-  # Validation job: Validates all workspace files before deployment
-  # - Checks JSON syntax in all .json files
-  # - Validates Python notebook syntax in notebook-content.py files
-  # - Ensures required metadata files exist (lakehouse.metadata.json, alm.settings.json)
-  # - Validates YAML syntax in workspace parameter.yml files
-  # Fails entire workflow if any validation fails
-  static-analysis:
-    name: Static Analysis
-    runs-on: ubuntu-latest
-    needs: get-workspaces
-    if: needs.get-workspaces.outputs.workspaces != ''
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyyaml
-
-      - name: Validate JSON files
-        run: |
-          echo "Validating JSON files..."
-          find "${{ env.WORKSPACES_DIRECTORY }}" -name "*.json" -type f | while IFS= read -r file; do
-            echo "Checking: $file"
-            if ! python -m json.tool "$file" > /dev/null 2>&1; then
-              echo "ERROR: Invalid JSON in $file"
-              exit 1
-            fi
-          done
-          echo "All JSON files are valid"
-
-      - name: Validate Python notebooks
-        run: |
-          echo "Validating Python notebook syntax..."
-          find "${{ env.WORKSPACES_DIRECTORY }}" -name "notebook-content.py" -type f | while IFS= read -r file; do
-            echo "Checking: $file"
-            if ! python -m py_compile "$file" > /dev/null 2>&1; then
-              echo "ERROR: Syntax error in notebook $file"
-              exit 1
-            else
-              echo "Checked: $file"
-            fi
-          done
-          echo "Notebook validation complete"
-
-      - name: Check required metadata files
-        run: |
-          echo "Checking for required metadata files..."
-          # Check lakehouses have required files
-          find "${{ env.WORKSPACES_DIRECTORY }}" -type d -name "*.Lakehouse" | while IFS= read -r dir; do
-            echo "Checking lakehouse: $dir"
-            [ -f "$dir/lakehouse.metadata.json" ] || (echo "Missing lakehouse.metadata.json in $dir" && exit 1)
-            [ -f "$dir/alm.settings.json" ] || (echo "Missing alm.settings.json in $dir" && exit 1)
-          done
-          echo "All required metadata files present"
-
-      - name: Validate workspace parameter.yml files
-        run: |
-          echo "Validating workspace parameter.yml files..."
-          find "${{ env.WORKSPACES_DIRECTORY }}" -mindepth 2 -maxdepth 2 -name "parameter.yml" -type f | while IFS= read -r file; do
-            echo "Checking: $file"
-            python -c "import yaml; yaml.safe_load(open('$file'))" || (echo "ERROR: Invalid YAML in $file" && exit 1)
-          done
-          echo "All parameter.yml files are valid"
-
   # Dev deployment job
   # Triggers:
   #   - Automatic: On push to main (deploys all workspaces)
@@ -133,7 +62,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     runs-on: ubuntu-latest
-    needs: [get-workspaces, static-analysis]
+    needs: get-workspaces
     if: |
       needs.get-workspaces.outputs.workspaces != '' &&
       (github.event_name == 'push' || 
@@ -233,7 +162,7 @@ jobs:
   deploy-test:
     name: Deploy to Test
     runs-on: ubuntu-latest
-    needs: [get-workspaces, static-analysis]
+    needs: get-workspaces
     if: |
       needs.get-workspaces.outputs.workspaces != '' &&
       github.event_name == 'workflow_dispatch' && inputs.environment == 'test'
@@ -328,7 +257,7 @@ jobs:
   deploy-prod:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [get-workspaces, static-analysis]
+    needs: get-workspaces
     if: |
       needs.get-workspaces.outputs.workspaces != '' &&
       github.event_name == 'workflow_dispatch' && inputs.environment == 'prod'

--- a/README.md
+++ b/README.md
@@ -210,14 +210,13 @@ graph LR
 For each workspace in the deployment:
 
 1. **Get Workspaces** - Identify all workspaces for deployment
-2. **Validate** - Run static analysis on JSON, YAML, and Python files
-3. **Authenticate** - Login using Service Principal (ClientSecretCredential)
-4. **Capture State** - Store current workspace state for rollback
-5. **Transform IDs** - Replace environment-specific IDs based on workspace `parameter.yml`
-6. **Deploy Items** - Publish items using `fabric-cicd` library
-7. **Clean Up Orphans** - Remove items not in repository
-8. **Rollback on Failure** - If any workspace fails, rollback all previously deployed workspaces
-9. **Report Status** - Display deployment summary in GitHub Actions
+2. **Authenticate** - Login using Service Principal (ClientSecretCredential)
+3. **Capture State** - Store current workspace state for rollback
+4. **Transform IDs** - Replace environment-specific IDs based on workspace `parameter.yml`
+5. **Deploy Items** - Publish items using `fabric-cicd` library
+6. **Clean Up Orphans** - Remove items not in repository
+7. **Rollback on Failure** - If any workspace fails, rollback all previously deployed workspaces
+8. **Report Status** - Display deployment summary in GitHub Actions
 
 ### Atomic Deployment with Rollback
 


### PR DESCRIPTION
## Description
This PR removes the `static-analysis` job from the GitHub Actions workflow, simplifying the deployment pipeline.

## Changes Made
- ✅ Removed entire `static-analysis` job from workflow
- ✅ Updated `deploy-dev` dependency from `[get-workspaces, static-analysis]` to `get-workspaces`
- ✅ Updated `deploy-test` dependency from `[get-workspaces, static-analysis]` to `get-workspaces`
- ✅ Updated `deploy-prod` dependency from `[get-workspaces, static-analysis]` to `get-workspaces`
- ✅ Removed "Validate" step from deployment process documentation
- ✅ Removed "Validated locally with static analysis" from PR template

## Files Updated
- `.github/workflows/fabric-deploy.yml` - Removed static-analysis job and updated dependencies
- `README.md` - Updated deployment process steps
- `.github/pull_request_template.md` - Removed static analysis checkbox

## Impact
**Before**: Workflow validated JSON, YAML, and Python files before deployment
**After**: Workflow proceeds directly from workspace discovery to deployment

## Benefits
- Faster deployments (no validation step)
- Simpler workflow with fewer jobs
- Deployment issues surface during actual deployment rather than pre-validation

## Testing
- [ ] Workflow runs successfully without static-analysis job
- [ ] All deployment jobs (dev, test, prod) execute correctly
- [ ] Job dependencies resolve properly

Closes #50
