### PR TITLE
Improve authentication error message when GitHub secrets are not configured

### DIFF
--- a/scripts/deployment_config.py
+++ b/scripts/deployment_config.py
@@ -26,3 +26,8 @@ ENV_FABRIC_CAPACITY_ID = "FABRIC_CAPACITY_ID"
 ENV_DEPLOYMENT_SP_OBJECT_ID = "DEPLOYMENT_SP_OBJECT_ID"
 ENV_FABRIC_ADMIN_GROUP_ID = "FABRIC_ADMIN_GROUP_ID"
 ENV_ACTIONS_RUNNER_DEBUG = "ACTIONS_RUNNER_DEBUG"
+ENV_GITHUB_ACTIONS = "GITHUB_ACTIONS"
+
+# Wiki URLs
+WIKI_SETUP_GUIDE_URL = "https://github.com/dc-floriangaerner/dc-fabric-cicd/wiki/Setup-Guide"
+WIKI_TROUBLESHOOTING_URL = "https://github.com/dc-floriangaerner/dc-fabric-cicd/wiki/Troubleshooting"


### PR DESCRIPTION
## Summary

Closes #80

When forking/copying the project without configuring GitHub secrets, users received a cryptic Azure SDK error with no actionable guidance. This PR replaces it with a clear message that explains what's missing and where to go.

## Changes

- **`scripts/deployment_config.py`** — added `ENV_GITHUB_ACTIONS`, `WIKI_SETUP_GUIDE_URL`, and `WIKI_TROUBLESHOOTING_URL` constants
- **`scripts/deploy_to_fabric.py`** — improved `create_azure_credential()` to detect CI environment and missing/partial secrets, raising a `ValueError` with direct wiki links
- **`tests/test_deploy_to_fabric_extended.py`** — replaced outdated tests and added 3 new cases covering CI detection, partial credentials, and no credentials in CI

## Before / After

**Before:**
```
[FAIL] VALIDATION ERROR: client_id should be the id of a Microsoft Entra application
```

**After (no secrets set in GitHub Actions):**
```
[FAIL] VALIDATION ERROR: None of the required GitHub secrets are configured: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET.

  These secrets authenticate the deployment pipeline to Microsoft Fabric
  using a Service Principal (Entra ID App Registration).

  Setup instructions : https://github.com/dc-floriangaerner/dc-fabric-cicd/wiki/Setup-Guide
  Troubleshooting    : https://github.com/dc-floriangaerner/dc-fabric-cicd/wiki/Troubleshooting#clientsecretcredential-authentication-failed
```

## Testing

- All 100 tests pass (98 passed, 2 xfailed)
- Coverage: 87% overall